### PR TITLE
Rename graphql types to fix compatibity with wp-graphql

### DIFF
--- a/src/graphql/apolloClient.js
+++ b/src/graphql/apolloClient.js
@@ -3,8 +3,8 @@ import { HttpLink } from 'apollo-link-http'
 import { InMemoryCache } from 'apollo-cache-inmemory'
 
 const client = new ApolloClient({
-  link: new HttpLink({ uri: 'http://bulletinlocaltest.local/graphql' }),
-  // link: new HttpLink({ uri: 'https://learn.wpgraphql.com/graphql' }),
+  // link: new HttpLink({ uri: 'http://bulletinlocaltest.local/graphql' }),
+  link: new HttpLink({ uri: 'https://www.wpgraphql.com/graphql' }),
   cache: new InMemoryCache()
 })
 

--- a/src/graphql/fragments.js
+++ b/src/graphql/fragments.js
@@ -1,7 +1,22 @@
 import gql from 'graphql-tag'
 
 export const postFragment = gql`
-  fragment PostData on postsConnection {
+  fragment PostData on RootQueryToPostConnection {
+    edges {
+      node {
+        id
+        title
+        date
+        featuredImage {
+          sourceUrl
+        }
+      }
+    }
+  }
+`
+
+export const postToCategory = gql`
+  fragment PostData on CategoryToPostConnection {
     edges {
       node {
         id

--- a/src/graphql/queries/categories.js
+++ b/src/graphql/queries/categories.js
@@ -1,5 +1,5 @@
 import gql from 'graphql-tag'
-import { postFragment } from '../fragments'
+import { postToCategory } from '../fragments'
 
 export const getCategories = gql`
   query getAllPosts {
@@ -15,5 +15,5 @@ export const getCategories = gql`
       }
     }
   }
-  ${postFragment}
+  ${postToCategory}
 `


### PR DESCRIPTION
WP GraphQL renamed a few things. That is why the older queries were not working.

Things that I have done:
- Changed the endpoint to `https://www.wpgraphql.com/graphql` so that I can run this locally(change it to your server's endpoint with you pull this branch.
- Renamed `postsConnection` type to `RootQueryToPostConnection`
- Made a new fragment for categories as the older type was incompatible.


Let me know if you have any questions.